### PR TITLE
fix: remove global export in Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - **Remote Configuration:** Support for fetching configuration from Consul and etcd3.
 
+### 🛡️ Fixed
+
+- **Integration Test Conflicts:** Resolved an issue where local environment variables
+were unintentionally overriding remote configuration providers during testing.
+
 ## [1.0.0] - 2026-05-04
 
 ### ✨ Added

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # --- Load environment variables from .env if it exists ---
 ifneq (,$(wildcard ./.env))
     include .env
-    export
 endif
 
 FILTERED_ARGS := $(filter-out --,$(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS)))

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/joho/godotenv"
 	"github.com/open-outbox/relay/internal/container"
 	"github.com/open-outbox/relay/internal/relay"
 	"github.com/open-outbox/relay/internal/telemetry"
@@ -22,7 +21,6 @@ import (
 
 // main initializes the application and starts the main execution loop.
 func main() {
-	_ = godotenv.Load()
 	if err := run(); err != nil {
 		log.Fatalf("Relay terminated with error: %v", err)
 	}

--- a/tests/integration/remote_config_test.go
+++ b/tests/integration/remote_config_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
@@ -38,17 +37,10 @@ PUBLISHER_TYPE: kafka
 `
 	seedConsul(t, endpoint, url, configYaml)
 
-	os.Setenv("REMOTE_CONFIG_PROVIDER", "consul")
-	os.Setenv("REMOTE_CONFIG_ENDPOINT", endpoint)
-	os.Setenv("REMOTE_CONFIG_PATH", "config/relay.yaml")
-	os.Setenv("REMOTE_CONFIG_TYPE", "yaml")
-
-	t.Cleanup(func() {
-		os.Unsetenv("REMOTE_CONFIG_PROVIDER")
-		os.Unsetenv("REMOTE_CONFIG_ENDPOINT")
-		os.Unsetenv("REMOTE_CONFIG_PATH")
-		os.Unsetenv("REMOTE_CONFIG_TYPE")
-	})
+	t.Setenv("REMOTE_CONFIG_PROVIDER", "consul")
+	t.Setenv("REMOTE_CONFIG_ENDPOINT", endpoint)
+	t.Setenv("REMOTE_CONFIG_PATH", "config/relay.yaml")
+	t.Setenv("REMOTE_CONFIG_TYPE", "yaml")
 
 	cfg, err := config.Load()
 
@@ -67,15 +59,9 @@ func TestLoad_RemoteConsul_KeyNotFound(t *testing.T) {
 	endpoint, _ := consulContainer.ApiEndpoint(ctx)
 
 	// 2. Point to a path that we NEVER seeded
-	os.Setenv("REMOTE_CONFIG_PROVIDER", "consul")
-	os.Setenv("REMOTE_CONFIG_ENDPOINT", endpoint)
-	os.Setenv("REMOTE_CONFIG_PATH", "non/existent/path.yaml")
-
-	t.Cleanup(func() {
-		os.Unsetenv("REMOTE_CONFIG_PROVIDER")
-		os.Unsetenv("REMOTE_CONFIG_ENDPOINT")
-		os.Unsetenv("REMOTE_CONFIG_PATH")
-	})
+	t.Setenv("REMOTE_CONFIG_PROVIDER", "consul")
+	t.Setenv("REMOTE_CONFIG_ENDPOINT", endpoint)
+	t.Setenv("REMOTE_CONFIG_PATH", "non/existent/path.yaml")
 
 	cfg, err := config.Load()
 


### PR DESCRIPTION
- Global export in Makefile were forcing .env variables into the shell environment, causing Viper to prioritize them over Consul during integration tests. Switched to internal Make variables to maintain local dev convenience without polluting the test environment.
- Removed loading .env from relay/main cause it was not necessary