### PR TITLE
ci: restrict documentation deployment to release tags

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,8 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ main ]
+    tags:
+      - 'v*'
     paths:
       - "docs/**"
       - "pkg/**"


### PR DESCRIPTION
Restrict documentation deployment to release tags